### PR TITLE
on eos signal from sink between src and webrtcbin, disconnect from whip

### DIFF
--- a/src/whip-client.c
+++ b/src/whip-client.c
@@ -372,8 +372,8 @@ static gboolean whip_initialize(void) {
 	}
 
 	if(eos_sink_name != NULL) {
-		GstElement* src = gst_bin_get_by_name(GST_BIN(pipeline), eos_sink_name);
-		GstPad* sinkpad = gst_element_get_static_pad(src, "sink");
+		GstElement *eossrc = gst_bin_get_by_name(GST_BIN(pipeline), eos_sink_name);
+		GstPad *sinkpad = gst_element_get_static_pad(eossrc, "sink");
 		gst_pad_set_event_function(sinkpad, source_events);
 		gst_object_unref(sinkpad);
 	}

--- a/src/whip-client.c
+++ b/src/whip-client.c
@@ -50,7 +50,6 @@ enum whip_state {
 /* Global properties */
 static GMainLoop *loop = NULL;
 static GstElement *pipeline = NULL, *pc = NULL;
-static GstBus *bus = NULL;
 static const char *audio_pipe = NULL, *video_pipe = NULL;
 static gboolean no_trickle = FALSE, gathering_done = FALSE,
 	follow_link = FALSE, force_turn = FALSE;

--- a/src/whip-client.c
+++ b/src/whip-client.c
@@ -129,7 +129,7 @@ static GOptionEntry opt_entries[] = {
 	{ "log-level", 'l', 0, G_OPTION_ARG_INT, &whip_log_level, "Logging level (0=disable logging, 7=maximum log level; default: 4)", NULL },
 	{ "disable-colors", 'o', 0, G_OPTION_ARG_NONE, &disable_colors, "Disable colors in the logging (default: enabled)", NULL },
 	{ "log-timestamps", 'L', 0, G_OPTION_ARG_NONE, &whip_log_timestamps, "Enable logging timestamps (default: disabled)", NULL },
-  { "eos-sink-name", 'e', 0, G_OPTION_ARG_STRING, &eos_sink_name, "GStreamer sink name for EOS signal", NULL },
+	{ "eos-sink-name", 'e', 0, G_OPTION_ARG_STRING, &eos_sink_name, "GStreamer sink name for EOS signal", NULL },
 	{ NULL },
 };
 

--- a/src/whip-client.c
+++ b/src/whip-client.c
@@ -128,7 +128,7 @@ static GOptionEntry opt_entries[] = {
 	{ "turn-server", 'T', 0, G_OPTION_ARG_STRING_ARRAY, &turn_server, "TURN server to use, if any; can be called multiple times (turn(s)://username:password@host:port?transport=[udp,tcp])", NULL },
 	{ "force-turn", 'F', 0, G_OPTION_ARG_NONE, &force_turn, "In case TURN servers are provided, force using a relay (default: false)", NULL },
 	{ "log-level", 'l', 0, G_OPTION_ARG_INT, &whip_log_level, "Logging level (0=disable logging, 7=maximum log level; default: 4)", NULL },
-	{ "eos-sink-name", 'E', 0, G_OPTION_ARG_STRING, &eos_sink_name, "GStreamer sink name for EOS signal", NULL },
+	{ "eos-sink-name", 'e', 0, G_OPTION_ARG_STRING, &eos_sink_name, "GStreamer sink name for EOS signal", NULL },
 	{ NULL },
 };
 
@@ -322,20 +322,16 @@ static void whip_options(void) {
 	WHIP_LOG(LOG_INFO, "\n");
 }
 
-static gboolean source_events(GstPad* pad,
-														GstObject* parent,
-														GstEvent* event) {
+static gboolean source_events(GstPad *pad, GstObject *parent, GstEvent *event) {
 	gboolean ret;
 
-	switch (GST_EVENT_TYPE(event)) {
+	switch(GST_EVENT_TYPE(event)) {
 		case GST_EVENT_EOS:
-			ret = gst_pad_event_default (pad, parent, event);
-			// g_print("source_events:GST_EVENT_EOS\n");
-			whip_disconnect("Shutting down");
+			ret = gst_pad_event_default(pad, parent, event);
+			whip_disconnect("Shutting down (EOS)");
 			break;
 		default: {
-			// g_print("source_events:default Got event %s\n", gst_event_type_get_name(GST_EVENT_TYPE(event)));
-			ret = gst_pad_event_default (pad, parent, event);
+			ret = gst_pad_event_default(pad, parent, event);
 			break;
 		}
 	}
@@ -377,8 +373,6 @@ static gboolean whip_initialize(void) {
 		gst_pad_set_event_function(sinkpad, source_events);
 		gst_object_unref(sinkpad);
 	}
-
-	g_object_set(pipeline, "message-forward", TRUE, NULL);
 
 	/* Get a pointer to the PeerConnection object */
 	pc = gst_bin_get_by_name(GST_BIN(pipeline), "sendonly");

--- a/src/whip-client.c
+++ b/src/whip-client.c
@@ -344,31 +344,6 @@ static gboolean source_events(GstPad* pad,
 	return ret;
 }
 
-static gboolean pipeline_bus_callback(GstBus *bus, GstMessage *message) {
-	switch (GST_MESSAGE_TYPE (message)) {
-		case GST_MESSAGE_ERROR: {
-			GError *err;
-			gchar *debug;
-			gst_message_parse_error(message, &err, &debug);
-			// g_print("pipeline_bus_callback:GST_MESSAGE_ERROR Error/code : %s/%d\n", err->message, err->code);
-			whip_disconnect("Shutting down");
-			g_error_free(err);
-			g_free(debug);
-			return FALSE;
-			break;
-		}
-		case GST_MESSAGE_EOS: {
-			//g_print("pipeline_bus_callback:GST_MESSAGE_EOS \n");
-			return FALSE;
-		}
-		default: {
-			//g_print("pipeline_bus_callback:default Got %s message \n", GST_MESSAGE_TYPE_NAME (message));
-			break;
-		}
-	}
-	return TRUE;
-}
-
 /* Helper method to initialize the GStreamer WebRTC stack */
 static gboolean whip_initialize(void) {
 	/* Prepare the pipeline, using the info we got from the command line */
@@ -396,11 +371,6 @@ static gboolean whip_initialize(void) {
 		g_error_free(error);
 		goto err;
 	}
-
-	bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
-	gst_bus_enable_sync_message_emission(bus);
-	gst_bus_set_sync_handler(bus, (GstBusSyncHandler) pipeline_bus_callback, NULL, NULL);
-	gst_object_unref(GST_OBJECT(bus));
 
 	if(eos_sink_name != NULL) {
 		GstElement* src = gst_bin_get_by_name(GST_BIN(pipeline), eos_sink_name);


### PR DESCRIPTION
EDIT
Removed the error listening hacky code. 

Now you pass in an extra param to give it a name of a sink between the source that may end by itself and webrtcbin Typically you're going to have a demuxer or a parser or a decoder anyway so just add a name to that "sink" and pass that name in as a param under `-e`