### PR TITLE
docker: pin to bullseye instead of sid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:sid AS builder
+FROM debian:bullseye AS builder
 
 RUN apt-get update --allow-releaseinfo-change && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This avoids the libsoup2/3 conflict described in #13