### PR TITLE
Switch HTTP stack to libsoup3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
-STUFF = $(shell pkg-config --cflags "gstreamer-webrtc-1.0 >= 1.16" "gstreamer-sdp-1.0 >= 1.16" gstreamer-video-1.0 libsoup-2.4 json-glib-1.0) -D_GNU_SOURCE
-STUFF_LIBS = $(shell pkg-config --libs "gstreamer-webrtc-1.0 >= 1.16" "gstreamer-sdp-1.0 >= 1.16" gstreamer-video-1.0 libsoup-2.4 json-glib-1.0)
+STUFF = $(shell pkg-config --cflags "gstreamer-webrtc-1.0 >= 1.16" "gstreamer-sdp-1.0 >= 1.16" gstreamer-video-1.0 libsoup-3.0 json-glib-1.0) -D_GNU_SOURCE
+STUFF_LIBS = $(shell pkg-config --libs "gstreamer-webrtc-1.0 >= 1.16" "gstreamer-sdp-1.0 >= 1.16" gstreamer-video-1.0 libsoup-3.0 json-glib-1.0)
 OPTS = -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wunused #-Werror #-O2
 GDB = -g -ggdb
 OBJS = src/whip-client.o

--- a/src/whip-client.c
+++ b/src/whip-client.c
@@ -944,11 +944,11 @@ static guint whip_http_send(whip_http_session *session, char *method,
 		/* Add an authorization header too */
 		char auth[1024];
 		g_snprintf(auth, sizeof(auth), "Bearer %s", token);
-		soup_message_headers_append(soup_message_get_response_headers(session->msg), "Authorization", auth);
+		soup_message_headers_append(soup_message_get_request_headers(session->msg), "Authorization", auth);
 	}
 	if(latest_etag != NULL) {
 		/* Add an If-Match header too with the available ETag */
-		soup_message_headers_append(soup_message_get_response_headers(session->msg), "If-Match", latest_etag);
+		soup_message_headers_append(soup_message_get_request_headers(session->msg), "If-Match", latest_etag);
 	}
 	/* Send the message synchronously */
 	GBytes *rb = NULL;


### PR DESCRIPTION
This PR addresses the infamous

```
libsoup2 symbols detected. Using libsoup2 and libsoup3 in the same process is not supported
```

error when compiling the WHIP client on a system where GStreamer is built against libsoup3, by basically using libsoup3 in the client too. Notice that this means the client will now be broken for installations where GStreamer is still based on libsoup2: unfortunately the changes between libsoup2 and libsoup3 are way too numerous to keep support for them both in the client, so I'd say if that's your case, just upgrade your setup.

I only did marginal testing in a local environment, and it seemed to work for me. Please test and provide feedback: as soon as I'm confident it works as expected, I'll merge.